### PR TITLE
MST Mod Remove count line from throwing stick

### DIFF
--- a/data/mods/More_Survival_Tools/items.json
+++ b/data/mods/More_Survival_Tools/items.json
@@ -178,7 +178,6 @@
     "material": "wood",
     "symbol": ";",
     "color": "brown",
-    "count": 4,
     "ammo_type": "thrown",
     "range": 0,
     "damage": 0,


### PR DESCRIPTION
<!--
### How to use
Leave the headings unless they don't apply to your PR, replace commented out text ( surrounded with <!-- and -​-> ) with text describing your PR.
-->

#### Summary
<!--
A one-line description of your change that will be extracted and added to the project changelog at https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
The format is: ```SUMMARY: Category "description"```  
The categories to choose from are: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N  
Example: ```SUMMARY: Content "Adds new mutation category 'Mouse'"```
See the Changelog Guidelines at https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md for explanations of the categories.
-->
```SUMMARY: Bugfixes "MST Remove "count" from throwing sticks```
#### Purpose of change
<!--
If there's an existing issue describing the problem this PR addresses or the feature it adds, please link it like: ```#1234```  
If it *fully* resolves an issue, link it like: ```Fixes #1234```  
Even if the issue describes the problem, please provide a few-sentence summary here.  
Example: ```Fixes #1234 - XL mutants cannot wear arm/leg splints due to missing OVERSIZE flag.```  
If there is no related issue, please describe the issue you are addressing, including how to trigger a bug if this is a bugfix.
-->
Many stats of the throwing sticks seem to be balanced around turning one heavy stick or similar item into a single throwing projectile but result in 4 throwing sticks with weird stats like a very small volume of 125ml with a relatively high weight and bashing damage for a wood item of that size. This pr makes their volume less silly, fix their volume to weight ratio and make the item fit its description. As a side effect this will make carrying a bunch of throwing sticks less desireably due to taking up more volume in your inventory, considering that they are very easy to make and still provide a very decent throwing weapon, i do not expect a negative impact on game balance from this change, but instead encourage to craft them when needed in the field or encourage to use throwing knives instead if volume is a valid concern,

#### Describe the solution
<!--
How does the feature work, or how does this fix a bug?  
The easier you make your solution to understand, the faster it can get merged.
-->
Removing the count line from the item will fix mentioned inconsistencies.

#### Describe alternatives you've considered
<!--
A clear and concise description of any alternative solutions or features you've considered.
-->
Change the casting recipe to use multiple sticks and change the volume of the resulting item to make more sense.

Or reduce weight and bashing damage and change description of the resulting item if the stick is actually supposed to be cut into 4 throwing items.
#### Additional context
<!--
Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. 
-->